### PR TITLE
removed \aclpaperid; added fontenc package

### DIFF
--- a/paper_styles/latex/naaclhlt2019.tex
+++ b/paper_styles/latex/naaclhlt2019.tex
@@ -16,13 +16,14 @@
 \usepackage{times}
 \usepackage{latexsym}
 
-% For common Latin-1 characters (including in bib files)
+% For proper rendering and hyphenation of words containing Latin characters (including in bib files)
 \usepackage[T1]{fontenc}
 % For Vietnamese characters
 % \usepackage[T5]{fontenc}
 % See https://www.latex-project.org/help/documentation/encguide.pdf for other character sets
 
-\usepackage{url}
+% This assumes your files are encoded as UTF8
+\usepackage[utf8]{inputenc}
 
 %\setlength\titlebox{5cm}
 % You can expand the titlebox if you need extra space

--- a/paper_styles/latex/naaclhlt2019.tex
+++ b/paper_styles/latex/naaclhlt2019.tex
@@ -16,10 +16,13 @@
 \usepackage{times}
 \usepackage{latexsym}
 
-\usepackage{url}
+% For common Latin-1 characters (including in bib files)
+\usepackage[T1]{fontenc}
+% For Vietnamese characters
+% \usepackage[T5]{fontenc}
+% See https://www.latex-project.org/help/documentation/encguide.pdf for other character sets
 
-%\aclfinalcopy % Uncomment this line for the final submission
-%\def\aclpaperid{***} %  Enter the acl Paper ID here
+\usepackage{url}
 
 %\setlength\titlebox{5cm}
 % You can expand the titlebox if you need extra space


### PR DESCRIPTION
@davidweichiang is working with Softconf to add paper ID stamping at submission time

added fontenc package to support Latin-1 encoded files exported by the Anthology (see https://github.com/acl-org/acl-anthology/issues/122)