### PR TITLE
Fix line wrapping in bibliography w/ hyperref

### DIFF
--- a/paper_styles/latex/acl2019.sty
+++ b/paper_styles/latex/acl2019.sty
@@ -99,6 +99,7 @@
 \ExecuteOptions{hyperref} % default is to use hyperref
 \ProcessOptions\relax
 \ifacl@hyperref
+  \PassOptionsToPackage{breaklinks}{hyperref}
   \RequirePackage{hyperref}
   \usepackage{xcolor}		% make links dark blue
   \definecolor{darkblue}{rgb}{0, 0, 0.5}


### PR DESCRIPTION
See the latest comments on issue #2. 

I think this is mainly a problem with older or mismatched versions of... natbib? Since it wasn't an issue on my machine, but cropped up when trying to use the style file on arxiv (which compiles latex with an older distribution and version of natbib).

Tested by uploading my paper latex to arxiv and compiling, as well as compiling locally w/ a relatively current version of natbib/latex.